### PR TITLE
「ゔ」を許可

### DIFF
--- a/frontend/src/components/Odai.vue
+++ b/frontend/src/components/Odai.vue
@@ -73,7 +73,7 @@ export default defineComponent({
       })
     }
 
-    const wordValid = computed(() => !(/^[ぁ-んー　]{4,6}$/.test(wordRef.value)))
+    const wordValid = computed(() => !(/^[ぁ-ゔー]{4,6}$/.test(wordRef.value)))
 
     watch(data, () => {
       if (data.game_state === STATE.GameStart) {

--- a/frontend/src/components/Odai.vue
+++ b/frontend/src/components/Odai.vue
@@ -39,7 +39,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, inject, ref, useRouter, onMounted, watch, reactive, useContext } from '@nuxtjs/composition-api'
+import { defineComponent, inject, ref, useRouter, onMounted, watch, reactive, useContext, computed } from '@nuxtjs/composition-api'
 import axios from 'axios'
 import { key } from '../utils/store'
 import { STATE, SET } from '../utils/socket'
@@ -50,7 +50,6 @@ export default defineComponent({
     const { app } = useContext()
     const store = inject(key)
     const wordRef = ref<string>('')
-    const wordValid = ref(false)
     const router = useRouter()
     const thema = ref('')
     const waiting = ref(false)
@@ -74,6 +73,8 @@ export default defineComponent({
       })
     }
 
+    const wordValid = computed(() => !(/^[ぁ-んー　]{4,6}$/.test(wordRef.value)))
+
     watch(data, () => {
       if (data.game_state === STATE.GameStart) {
         waiting.value = false
@@ -82,7 +83,6 @@ export default defineComponent({
       }
     }, { deep: true })
     watch(wordRef, () => {
-      wordValid.value = wordRef.value.match(/^[ぁ-んー　]{4,6}$/) == null
       if (!wordValid.value && wordRef.value !== '') {
         axios.get(`${location.protocol}//${location.host}/api/suggest/search?hl=ja&q=${wordRef.value}&output=toolbar`, { responseType: 'document' }).then((response) => {
           const xml = response.data as XMLDocument

--- a/frontend/src/components/Play.vue
+++ b/frontend/src/components/Play.vue
@@ -188,7 +188,7 @@ export default defineComponent({
     })
 
     const ngCharValid = computed(() =>
-      ngChar.value !== '' && !(/^[ぁ-んー　]{1}$/.test(ngChar.value)))
+      ngChar.value !== '' && !(/^[ぁ-ゔー]{1}$/.test(ngChar.value)))
     const checkDuplicateNgChar = computed(() =>
       ngChar.value !== '' && ngCharas.value.find(item => item.char === ngChar.value))
 

--- a/frontend/src/components/Play.vue
+++ b/frontend/src/components/Play.vue
@@ -101,7 +101,7 @@
 </template>
 
 <script lang="ts">
-import { defineComponent, inject, ref, watch, onMounted, reactive, useRouter, useSlots } from '@nuxtjs/composition-api'
+import { defineComponent, inject, ref, watch, onMounted, reactive, useRouter, useSlots, computed } from '@nuxtjs/composition-api'
 import { key } from '../utils/store'
 import { SET, WORDSTATE } from '../utils/socket'
 import SquareCom from './parts/Square.vue'
@@ -123,8 +123,6 @@ export default defineComponent({
     const user = store.data.users.filter(u => u.Id === store.state.clientId)[0]
     const anotherUsers = ref<{ Id: string; Name: string; }[]>(store.data.users.filter(u => u.Id !== store.state.clientId))
     const ngChar = ref('')
-    const ngCharValid = ref(true)
-    const checkDuplicateNgChar = ref(false)
     const modalRef = ref()
     const data = reactive(store.data)
     const nextTurn = ref(store.data.next_turn)
@@ -189,10 +187,10 @@ export default defineComponent({
       ngLast!.scrollIntoView()
     })
 
-    watch(ngChar, () => {
-      ngCharValid.value = ngChar.value !== '' && ngChar.value.match(/^[ぁ-んー　]{1}$/) == null
-      checkDuplicateNgChar.value = ngChar.value !== '' && ngCharas.value.filter(item => item.char === ngChar.value).length > 0
-    })
+    const ngCharValid = computed(() =>
+      ngChar.value !== '' && !(/^[ぁ-んー　]{1}$/.test(ngChar.value)))
+    const checkDuplicateNgChar = computed(() =>
+      ngChar.value !== '' && ngCharas.value.find(item => item.char === ngChar.value))
 
     // watch(nextTurn, () => {
     //   if (anotherUsers.value.filter(u => u.Id === nextTurn.value) !== [] &&


### PR DESCRIPTION
related to #27

# やったこと
## リファクタ
- 文字のバリデーションに使われているWatcherをComputed Propertyに置き換え
  - より明示的な為
 
## 変更
- 単語内及びNG文字入力にて許可される文字に「ゔ」を追加、並びに全角スペースを削除

# 所感
これで動くってことはサーバーでバリデーションしてないな…？（わるいかお）