### PR TITLE
🐛: 引き分け時に挙動がおかしくなるバグ修正

### DIFF
--- a/backend/constant.go
+++ b/backend/constant.go
@@ -5,17 +5,17 @@ var roomMaxPlayer int = 2
 var themas []string = []string{"動物", "お菓子", "食べ物", "地名", "日用品", "飲み物", "乗り物"}
 
 const (
-	Initial      = iota
-	PlayerFilled = iota
-	GameStart    = iota
-	GameEnd      = iota
-	GameStop     = iota
-	GameDrawEnd  = iota
+	Initial = iota
+	PlayerFilled
+	GameStart
+	GameEnd
+	GameStop
+	GameDrawEnd
 )
 
 const (
 	HiddenWord = iota
-	OpenedWord = iota
+	OpenedWord
 )
 
 const maxMessageSize = 512

--- a/backend/constant.go
+++ b/backend/constant.go
@@ -10,6 +10,7 @@ const (
 	GameStart    = iota
 	GameEnd      = iota
 	GameStop     = iota
+	GameDrawEnd  = iota
 )
 
 const (

--- a/backend/room.go
+++ b/backend/room.go
@@ -12,7 +12,7 @@ type Room struct {
 	available     bool
 	clients       Clients
 	gameState     int
-	gameTurn int
+	gameTurn      int
 	thema         string
 	nextClientIdx int
 	clientIds     []string
@@ -100,9 +100,17 @@ func (r *Room) gameStart() {
 func (r *Room) gameEnd(c *Client) {
 	r.WithLockRoom(func() {
 		log.Printf("Game End")
-		r.gameState = GameEnd
-		r.winner = c.id
+		if c != nil {
+			r.gameState = GameEnd
+			r.setWinner(c)
+		} else {
+			r.gameState = GameDrawEnd
+		}
 	})
+}
+
+func (r *Room) setWinner(c *Client) {
+	r.winner = c.id
 }
 
 func (r *Room) checkEndGame() (bool, *Client) {
@@ -122,6 +130,9 @@ func (r *Room) checkEndGame() (bool, *Client) {
 		} else {
 			winner = client
 		}
+	}
+	if passedPlayer == len(r.clients) {
+		return true, nil
 	}
 	if passedPlayer == len(r.clients)-1 {
 		return true, winner

--- a/frontend/src/components/Result.vue
+++ b/frontend/src/components/Result.vue
@@ -11,6 +11,9 @@
         <h3 v-else-if="store.data.game_state == STATE.GameStop" class="card-title text-center">
           対戦相手が退出しました
         </h3>
+        <h3 v-else-if="store.data.game_state == STATE.GameDrawEnd" class="card-title text-center">
+          引き分け
+        </h3>
         <h4 v-if="store.data.game_state != undefined && store.data.game_state == STATE.GameEnd" class="text-center">
           {{ winner() }}の勝利
         </h4>

--- a/frontend/src/layouts/default.vue
+++ b/frontend/src/layouts/default.vue
@@ -32,7 +32,7 @@ export default defineComponent({
         clearInterval(pingFunc())
         return
       }
-      if (data.game_state === STATE.GameStop || data.game_state === STATE.GameEnd) {
+      if (data.game_state === STATE.GameStop || data.game_state === STATE.GameEnd || data.game_state === STATE.GameDrawEnd) {
         injectedStore.state.socket.close()
       }
     }, { deep: true })

--- a/frontend/src/utils/socket/index.ts
+++ b/frontend/src/utils/socket/index.ts
@@ -20,6 +20,7 @@ export enum STATE {
     GameStart,
     GameEnd,
     GameStop,
+    GameDrawEnd
 }
 
 export enum SET {


### PR DESCRIPTION
バグ元: https://mixigroup.slack.com/archives/C03BYFB9CCE/p1650878908643309?thread_ts=1650878762.485239&cid=C03BYFB9CCE

## 修正結果

https://user-images.githubusercontent.com/14112016/165116580-302ecd9d-6f37-475a-9073-a35090674388.mov

## 方針
- バグの原因は、今の実装では勝ち負けの2種類しかないため、同時に文字を開けられた場合には勝敗判定が終わらず無限に続いてしまう状態になっていた。そのため、同時に文字開けが起こったときに「引き分け」を追加する

## 内容
### Backend
- 勝敗判定を行う`checkEndGame`関数にて、「引き分け」判定を追加した。
https://github.com/ng-word-game/ng-word-game/blob/8c2e62517c90a00b023c7dca258ab9b3a7302802/backend/room.go#L108
- ゲーム終了時には`gameStatus`に`GameEnd`を渡すことで、ゲーム終了(一人の勝者がいる)としていたが、引き分け時には、新しく`gameStatus`に`GameDrawEnd`を渡すことで、引き分けを伝える

### Frontend
- Backendで追加した`GameDrawEnd`を受け取ったらwebsocketコネクションを終了し、`Result画面`に遷移して「引き分け」表示