### PR TITLE
🐛/room作成画面で固まるバグ修正

### DIFF
--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -38,15 +38,15 @@ type outbound struct {
 	NextTurn  string               `json:"next_turn"`
 	Winner    string               `json:"winner"`
 	NgChars   []NgChar             `json:"ng_chars"`
-	Turn int `json:"turn"`
+	Turn      int                  `json:"turn"`
 }
 
 func createOutbound(result int, room *Room) ([]byte, error) {
 	room.mux.RLock()
 	defer func() {
-		if err:=recover(); err!=nil {
+		if err := recover(); err != nil {
 			log.Println(err)
-		 }
+		}
 	}()
 	defer room.mux.RUnlock()
 	clientNames := []struct {

--- a/backend/handlers.go
+++ b/backend/handlers.go
@@ -145,6 +145,7 @@ func (r *Room) run() {
 				client.send <- out
 			}
 			if clientsLen == 0 {
+				r.available = false
 				log.Println("close room, goroutine: ", runtime.NumGoroutine())
 				return
 			}


### PR DESCRIPTION
### バグ内容
ルーム作成後に再読み込みを行うとエラーになる

https://user-images.githubusercontent.com/14112016/166241611-35acc09e-d7a9-47c0-96be-809550952200.mov

### バグ原因
- ルーム作成後、再読み込みを行うとルームに入っているプレイヤーはnullになるがroom取得時にnullなプレイヤーを読みに行ってしまい、エラーになる
参考: 
	- ルーム作成時のレスポンス
`{"rooms":[{"id":"1c5d0244-7303-4905-84ed-793601d434a2","num":1,"max_player":2,"players":["a"]}]}`
	- 再読み込み後のレスポンス
`{"rooms":[{"id":"1c5d0244-7303-4905-84ed-793601d434a2","num":0,"max_player":2,"players":null}]}`

## 解決方針
- ルームには生存を表す`available`フラグをつけている
https://github.com/ng-word-game/ng-word-game/blob/fe7771d8140b91bc0bf25676f2c837f7eb55687f/backend/room.go#L12
- room取得時には`available`なroomを返すようにしている
https://github.com/ng-word-game/ng-word-game/blob/fe7771d8140b91bc0bf25676f2c837f7eb55687f/backend/handlers.go#L289
- ルームから最後のプレイヤーが退出した時に`available`を`false`にする

## 解決後

https://user-images.githubusercontent.com/14112016/166244480-46982a8e-c2aa-4d83-b2cd-48872aff7c94.mov

- ルーム作成時のレスポンス
`{"rooms":[{"id":"b698f0e6-be7f-403e-acce-f4a72dd1aa60","num":1,"max_player":2,"players":["a"]}]}`
	- 再読み込み後のレスポンス
`{"rooms":null}`
